### PR TITLE
Fixed bug (cannot reuse hashtags)

### DIFF
--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -11,7 +11,7 @@ class Tweet < ApplicationRecord
       hashtag = Hashtag.find_or_create_by( tag: tag)
 
       #hashtag = Hashtag.new(tag: tag)
-      hashtag.save
+      #hashtag.save
       self.hashtags << hashtag
     end
   end

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -9,9 +9,6 @@ class Tweet < ApplicationRecord
     content.scan(/#\w+/).each do |tag|
 
       hashtag = Hashtag.find_or_create_by( tag: tag)
-
-      #hashtag = Hashtag.new(tag: tag)
-      #hashtag.save
       self.hashtags << hashtag
     end
   end

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -7,7 +7,10 @@ class Tweet < ApplicationRecord
 
   def generate_hashtags
     content.scan(/#\w+/).each do |tag|
-      hashtag = Hashtag.new(tag: tag)
+
+      hashtag = Hashtag.find_or_create_by( tag: tag)
+
+      #hashtag = Hashtag.new(tag: tag)
       hashtag.save
       self.hashtags << hashtag
     end


### PR DESCRIPTION
In tweet.rb, changed 
  hashtag = Hashtag.new(tag: tag)
to
  hashtag = Hashtag.find_or_create_by( tag: tag)
so that if the hashtag already exists (is found), then the app will not insert a new record into the hashtags table.